### PR TITLE
marlin: Enable maruos for sailfish

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -2,3 +2,7 @@ PRODUCT_MAKEFILES := \
 	$(LOCAL_DIR)/aosp_marlin.mk \
 	$(LOCAL_DIR)/aosp_marlin_svelte.mk \
 	$(LOCAL_DIR)/aosp_sailfish.mk
+
+# maru
+PRODUCT_MAKEFILES += \
+	$(LOCAL_DIR)/maru_sailfish.mk

--- a/BoardConfigLineage.mk
+++ b/BoardConfigLineage.mk
@@ -9,4 +9,8 @@ TARGET_KERNEL_SOURCE := kernel/google/marlin
 # Telephony
 TARGET_PROVIDES_TELEPHONY_EXT := true
 
+# maru
+# Override kernel config
+TARGET_KERNEL_CONFIG := maru_marlin_defconfig
+# -include vendor/google/marlin/BoardConfigVendor.mk
 -include vendor/google/marlin/BoardConfigVendor.mk

--- a/device-common.mk
+++ b/device-common.mk
@@ -303,6 +303,11 @@ PRODUCT_COPY_FILES += \
     device/google/marlin/init.foreground.sh:$(TARGET_COPY_OUT_VENDOR)/bin/init.foreground.sh \
     device/google/marlin/init.qcom.devstart.sh:$(TARGET_COPY_OUT_VENDOR)/bin/init.qcom.devstart.sh
 
+# maru
+PRODUCT_COPY_FILES += \
+    device/google/marlin/init.common.rc:root/init.sailfish.rc \
+    device/google/marlin/init.common.rc:root/init.marlin.rc
+
 # Reduce client buffer size for fast audio output tracks
 PRODUCT_PROPERTY_OVERRIDES += \
     af.fast_track_multiplier=1
@@ -313,7 +318,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Write Manufacturer & Model information in created media files.
 # IMPORTANT: ONLY SET THIS PROPERTY TO TRUE FOR PUBLIC DEVICES
-ifneq ($(filter lineage_sailfish% aosp_sailfish% sailfish% lineage_marlin% aosp_marlin% marlin%, $(TARGET_PRODUCT)),)
+# maru
+# ifneq ($(filter lineage_sailfish% aosp_sailfish% sailfish% lineage_marlin% aosp_marlin% marlin%, $(TARGET_PRODUCT)),)
+ifneq ($(filter lineage_sailfish% aosp_sailfish% sailfish% lineage_marlin% aosp_marlin% marlin% maru_sailfish%, $(TARGET_PRODUCT)),)
 PRODUCT_PROPERTY_OVERRIDES += \
     media.recorder.show_manufacturer_and_model=true
 else

--- a/device-sailfish.mk
+++ b/device-sailfish.mk
@@ -69,3 +69,6 @@ PRODUCT_PACKAGES += \
 # Fingerprint
 PRODUCT_PACKAGES += \
     fingerprint.sailfish
+
+# maru
+$(call inherit-product, vendor/maruos/device-maru.mk)

--- a/fstab.common
+++ b/fstab.common
@@ -8,7 +8,8 @@
 #<src>                                                  <mnt_point>         <type>  <mnt_flags and options>     <fs_mgr_flags>
 /dev/block/platform/soc/624000.ufshc/by-name/system     /                   ext4    ro,barrier=1                wait,slotselect,verify
 /dev/block/platform/soc/624000.ufshc/by-name/modem      /firmware/radio     vfat    ro,shortname=lower,uid=1000,gid=0,dmask=227,fmask=337,context=u:object_r:firmware_file:s0   wait,slotselect
-/dev/block/platform/soc/624000.ufshc/by-name/userdata   /data               ext4    errors=panic,noatime,nosuid,nodev,barrier=1,noauto_da_alloc  latemount,wait,check,formattable,fileencryption=ice,quota
+#/dev/block/platform/soc/624000.ufshc/by-name/userdata   /data               ext4    errors=panic,noatime,nosuid,nodev,barrier=1,noauto_da_alloc  latemount,wait,check,formattable,fileencryption=ice,quota
+/dev/block/platform/soc/624000.ufshc/by-name/userdata   /data               ext4    errors=panic,noatime,barrier=1,noauto_da_alloc  latemount,wait,check,formattable,fileencryption=ice,quota
 /dev/block/zram0                                        none                swap    defaults                    zramsize=536870912,max_comp_streams=4
 /dev/block/platform/soc/624000.ufshc/by-name/misc       /misc               emmc    defaults                    defaults
 /devices/*/xhci-hcd.0.auto/usb*                         auto                vfat    defaults                    voldmanaged=usb:auto

--- a/init.common.rc
+++ b/init.common.rc
@@ -1,3 +1,6 @@
+# maru
+import init.maru.rc
+
 on charger
     write /sys/devices/system/cpu/cpu2/online 0
     write /sys/devices/system/cpu/cpu3/online 0

--- a/lineage-sailfish.mk
+++ b/lineage-sailfish.mk
@@ -1,0 +1,26 @@
+# Boot animation
+TARGET_SCREEN_HEIGHT := 1920
+TARGET_SCREEN_WIDTH := 1080
+
+# Inherit some common Lineage stuff.
+$(call inherit-product, vendor/lineage/config/common_full_phone.mk)
+
+# Inherit device configuration
+$(call inherit-product, device/google/marlin/aosp_sailfish.mk)
+
+-include device/google/marlin/sailfish/device-lineage.mk
+
+## Device identifier. This must come after all inclusions
+PRODUCT_NAME := maruos_sailfish
+PRODUCT_BRAND := google
+PRODUCT_MODEL := Pixel
+TARGET_MANUFACTURER := HTC
+PRODUCT_RESTRICT_VENDOR_FILES := false
+
+PRODUCT_BUILD_PROP_OVERRIDES += \
+    PRODUCT_NAME=sailfish \
+    PRIVATE_BUILD_DESC="sailfish-user 8.1.0 OPM4.171019.021.P1 4820305 release-keys"
+
+BUILD_FINGERPRINT := google/sailfish/sailfish:8.1.0/OPM4.171019.021.P1/4820305:user/release-keys
+
+$(call inherit-product-if-exists, vendor/google_devices/marlin/device-vendor-sailfish.mk)

--- a/maru_sailfish.mk
+++ b/maru_sailfish.mk
@@ -1,0 +1,11 @@
+# -----------------------------------------------------------------------------
+# Include LineageOS stuff
+
+$(call inherit-product, device/google/marlin/lineage-sailfish.mk)
+
+# -----------------------------------------------------------------------------
+# Maru stuff
+
+$(call inherit-product, vendor/maruos/device-maru.mk)
+PRODUCT_NAME := maru_sailfish
+

--- a/sailfish/BoardConfig.mk
+++ b/sailfish/BoardConfig.mk
@@ -84,6 +84,13 @@ BOARD_USERDATAIMAGE_PARTITION_SIZE := 10737418240
 BOARD_PERSISTIMAGE_PARTITION_SIZE := 33554432
 BOARD_PERSISTIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)
+# maru
+# ~314MB vendor image. Why 314MB? Use busybox fdisk -l /dev/block/sda32
+# in adb shell to get the size.
+# Why /dev/block/sda32? Use mount | grep vendor in adb shell to get
+# the block of vendor.
+BOARD_VENDORIMAGE_PARTITION_SIZE := 314572800
+BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := ext4
 
 TARGET_USES_ION := true
 TARGET_USES_NEW_ION_API :=true
@@ -101,6 +108,9 @@ ifneq ($(filter sailfish sailfishf, $(TARGET_PRODUCT)),)
 BOARD_SEPOLICY_DIRS += device/google/marlin/sepolicy/verizon
 endif
 BOARD_PLAT_PRIVATE_SEPOLICY_DIR := device/google/marlin/sepolicy/private
+
+# maru
+BOARD_PLAT_PRIVATE_SEPOLICY_DIR += vendor/maruos/sepolicy
 
 BOARD_EGL_CFG := device/google/marlin/egl.cfg
 

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -30,3 +30,5 @@
 add_lunch_combo aosp_marlin-userdebug
 add_lunch_combo aosp_marlin_svelte-userdebug
 add_lunch_combo aosp_sailfish-userdebug
+# maru
+add_lunch_combo maru_sailfish-userdebug


### PR DESCRIPTION
1. Include MaruOS vendor config.
2. Enable vendor.img building.
3. Use vendor binaries in vendor/google_devices/marlin
   and vendor/google_devics/sailfish extracted by
   android-prepare-vendor. And LineageOS supports those
   directories.